### PR TITLE
Fix severe performance degradation when viewing maps with animated studio models

### DIFF
--- a/src/bsp/Bsp.cpp
+++ b/src/bsp/Bsp.cpp
@@ -13898,7 +13898,7 @@ void Bsp::import_mdl_to_bsp(int ent, int generateClipnodes, bool splitMeshes)
 						tmpMesh.push_back(rendmdl->mdl_mesh_groups[group][meshid]);
 						if (generateClipnodes)
 						{
-							for (auto v : rendmdl->mdl_mesh_groups[group][meshid].verts)
+							for (auto v : *rendmdl->mdl_mesh_groups[group][meshid].verts)
 								all_verts.push_back((angle_mat * vec4(v.pos.flipUV(), 1.0f)).xyz());
 						}
 
@@ -13930,7 +13930,7 @@ void Bsp::import_mdl_to_bsp(int ent, int generateClipnodes, bool splitMeshes)
 						merged_meshes.push_back(rendmdl->mdl_mesh_groups[group][meshid]);
 						if (generateClipnodes)
 						{
-							for (auto v : rendmdl->mdl_mesh_groups[group][meshid].verts)
+							for (auto v : *rendmdl->mdl_mesh_groups[group][meshid].verts)
 								all_verts.push_back((angle_mat * vec4(v.pos.flipUV(), 1.0f)).xyz());
 						}
 					}
@@ -14196,7 +14196,7 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 		std::vector<int> newVertIndexes;
 
 		int startVertCount = vertCount;
-		int newVertCount = startVertCount + (int)(mesh_verts.size());
+		int newVertCount = startVertCount + (int)(mesh_verts->size());
 
 		vec3* newverts = new vec3[newVertCount];
 		memcpy(newverts, verts, startVertCount * sizeof(vec3));
@@ -14212,8 +14212,8 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 
 		for (v = (int)startVertCount; v < newVertCount; v++)
 		{
-			newverts[v] = (angles * vec4(mesh_verts[v - startVertCount].pos.unflip(), 1.0f)).xyz();
-			newuv[v] = { mesh_verts[v - startVertCount].u, mesh_verts[v - startVertCount].v };
+			newverts[v] = (angles * vec4((*mesh_verts)[v - startVertCount].pos.unflip(), 1.0f)).xyz();
+			newuv[v] = { (*mesh_verts)[v - startVertCount].u, (*mesh_verts)[v - startVertCount].v };
 			newVertIndexes.push_back(v);
 			expandBoundingBox(newverts[v], mins, maxs);
 		}
@@ -14222,7 +14222,7 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 		std::map<int, int> vertToSurfedge;
 		bool inverse = false;
 		unsigned int startEdge = edgeCount;
-		int newdedgescount = startEdge + ((int)(mesh_verts.size()) + 1) / 2;
+		int newdedgescount = startEdge + ((int)(mesh_verts->size()) + 1) / 2;
 		BSPEDGE32* newedges = new BSPEDGE32[newdedgescount];
 		memcpy(newedges, edges, startEdge * sizeof(BSPEDGE32));
 		replace_lump(LUMP_EDGES, newedges, newdedgescount * sizeof(BSPEDGE32));
@@ -14231,10 +14231,10 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 
 
 		v = 0;
-		for (unsigned int i = 0; i < mesh_verts.size(); i += 2)
+		for (unsigned int i = 0; i < mesh_verts->size(); i += 2)
 		{
 			unsigned int v0 = i;
-			unsigned int v1 = (i + 1) % mesh_verts.size();
+			unsigned int v1 = (i + 1) % mesh_verts->size();
 			newedges[startEdge + v] = BSPEDGE32((unsigned int)newVertIndexes[v0], (unsigned int)newVertIndexes[v1]);
 
 			vertToSurfedge[v0] = startEdge + v;
@@ -14250,7 +14250,7 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 		inverse = false;
 
 		int startSurfedgeCount = surfedgeCount;
-		int newsurfedges_count = startSurfedgeCount + (int)(mesh_verts.size());
+		int newsurfedges_count = startSurfedgeCount + (int)(mesh_verts->size());
 		int* newsurfedges = new int[newsurfedges_count];
 		memcpy(newsurfedges, surfedges, startSurfedgeCount * sizeof(int));
 		replace_lump(LUMP_SURFEDGES, newsurfedges, newsurfedges_count * sizeof(int));
@@ -14262,7 +14262,7 @@ int Bsp::import_mdl_to_bspmodel(std::vector<StudioMesh>& meshes, mat4x4 angles, 
 			newsurfedges[v] = vertToSurfedge[v - (int)startSurfedgeCount];
 		}
 
-		int numTriangles = (int)(mesh_verts.size()) / 3;
+		int numTriangles = (int)(mesh_verts->size()) / 3;
 		modelFaces += (int)numTriangles;
 
 		int startFaceCount = faceCount;

--- a/src/editor/BspRenderer.cpp
+++ b/src/editor/BspRenderer.cpp
@@ -3268,7 +3268,7 @@ void BspRenderer::drawPointEntities(std::vector<int> highlightEnts, int pass)
 			if (g_render_flags & RENDER_SELECTED_AT_TOP)
 				glDepthFunc(GL_ALWAYS);
 			if ((g_render_flags & RENDER_MODELS) && (renderEnts[i].spr
-				|| (renderEnts[i].mdl && renderEnts[i].mdl->mdl_mesh_groups.size())))
+				|| (renderEnts[i].mdl && renderEnts[i].mdl->hasRenderableMeshes())))
 			{
 				if (pass == REND_PASS_MODELSHADER)
 				{
@@ -3328,7 +3328,7 @@ void BspRenderer::drawPointEntities(std::vector<int> highlightEnts, int pass)
 		else
 		{
 			if ((g_render_flags & RENDER_MODELS) && (renderEnts[i].spr
-				|| (renderEnts[i].mdl && renderEnts[i].mdl->mdl_mesh_groups.size())))
+				|| (renderEnts[i].mdl && renderEnts[i].mdl->hasRenderableMeshes())))
 			{
 				if (pass == REND_PASS_MODELSHADER)
 				{

--- a/src/gl/VertexBuffer.cpp
+++ b/src/gl/VertexBuffer.cpp
@@ -15,7 +15,7 @@ VertexBuffer::VertexBuffer(ShaderProgram* shaderProgram, void* dat, int _numVert
     setData(dat, _numVerts);
 }
 
-VertexBuffer::~VertexBuffer()
+VertexBuffer::~VertexBuffer() noexcept
 {
     deleteBuffer();
     if (ownData && data)
@@ -24,6 +24,61 @@ VertexBuffer::~VertexBuffer()
     }
     data = nullptr;
     numVerts = 0;
+}
+
+VertexBuffer::VertexBuffer(VertexBuffer&& other) noexcept
+    : shaderProgram(other.shaderProgram)
+    , numVerts(other.numVerts)
+    , primitive(other.primitive)
+    , frameId(other.frameId)
+    , ownData(other.ownData)
+    , uploaded(other.uploaded)
+    , data(other.data)
+    , vboId(other.vboId)
+    , vaoId(other.vaoId)
+{
+    // Reset the other object so it doesn't delete the resources
+    other.shaderProgram = nullptr;
+    other.data = nullptr;
+    other.numVerts = 0;
+    other.vboId = 0xFFFFFFFF;
+    other.vaoId = 0xFFFFFFFF;
+    other.ownData = false;
+    other.uploaded = false;
+}
+
+VertexBuffer& VertexBuffer::operator=(VertexBuffer&& other) noexcept
+{
+    if (this != &other)
+    {
+        // Clean up existing resources
+        deleteBuffer();
+        if (ownData && data)
+        {
+            delete[] data;
+        }
+
+        // Transfer ownership from other
+        shaderProgram = other.shaderProgram;
+        numVerts = other.numVerts;
+        primitive = other.primitive;
+        frameId = other.frameId;
+        ownData = other.ownData;
+        uploaded = other.uploaded;
+        data = other.data;
+        vboId = other.vboId;
+        vaoId = other.vaoId;
+
+        // Reset the other object
+        other.shaderProgram = nullptr;
+        other.data = nullptr;
+        other.numVerts = 0;
+        other.vboId = 0xFFFFFFFF;
+        other.vaoId = 0xFFFFFFFF;
+        other.ownData = false;
+        other.uploaded = false;
+    }
+    return *this;
 }
 
 void VertexBuffer::setData(void* _data, int _numVerts)

--- a/src/gl/VertexBuffer.h
+++ b/src/gl/VertexBuffer.h
@@ -16,7 +16,15 @@ public:
 	// Specify which common attributes to use. They will be located in the
 	// shader program. If passing data, note that data is not copied, but referenced
 	VertexBuffer(ShaderProgram* shaderProgram, void* dat, int numVerts, int primitive = 0);
-	~VertexBuffer();
+	~VertexBuffer() noexcept;
+
+	// Delete copy operations since this class manages OpenGL resources
+	VertexBuffer(const VertexBuffer&) = delete;
+	VertexBuffer& operator=(const VertexBuffer&) = delete;
+
+	// Move operations transfer ownership of OpenGL resources
+	VertexBuffer(VertexBuffer&& other) noexcept;
+	VertexBuffer& operator=(VertexBuffer&& other) noexcept;
 
 	// Note: Data is not copied into the class - don't delete your data.
 	//       Data will be deleted when the buffer is destroyed.

--- a/src/mdl/mdl_studio.cpp
+++ b/src/mdl/mdl_studio.cpp
@@ -5,6 +5,68 @@
 #include "Settings.h"
 #include "Renderer.h"
 #include "forcecrc32.h"
+#include <chrono>
+#include <memory>
+#include <cmath>
+#include <cfloat>
+
+void StudioModel::invalidateFrameCache()
+{
+    ++cacheStateVersion;
+    frameCache.clear();
+}
+
+std::shared_ptr<StudioModel::CachedFrame> StudioModel::buildCachedFrame()
+{
+    auto frame = std::make_shared<CachedFrame>();
+    frame->meshGroups.resize(mdl_mesh_groups.size());
+
+    for (size_t body = 0; body < mdl_mesh_groups.size(); ++body)
+    {
+        const auto& srcBody = mdl_mesh_groups[body];
+        auto& dstBody = frame->meshGroups[body];
+        dstBody.reserve(srcBody.size());
+
+        for (const auto& srcMesh : srcBody)
+        {
+            StudioMesh dstMesh;
+            dstMesh.texture = srcMesh.texture;
+
+            if (srcMesh.verts)
+            {
+                dstMesh.verts = std::make_shared<std::vector<modelVert>>(*srcMesh.verts);
+            }
+            else
+            {
+                dstMesh.verts = std::make_shared<std::vector<modelVert>>();
+            }
+
+            dstMesh.buffer = std::shared_ptr<VertexBuffer>(new VertexBuffer(g_app->modelShader, nullptr, 0, GL_TRIANGLES));
+            if (dstMesh.verts && !dstMesh.verts->empty())
+            {
+                dstMesh.buffer->setData(&(*dstMesh.verts)[0], static_cast<int>(dstMesh.verts->size()));
+            }
+
+            dstBody.push_back(std::move(dstMesh));
+        }
+    }
+
+    frame->mins = mins;
+    frame->maxs = maxs;
+    frame->hasBounds = true;
+
+    return frame;
+}
+
+StudioModel::FrameKey StudioModel::makeFrameKey(int frameIndex) const
+{
+    return FrameKey{ m_sequence, m_body, m_skinnum, frameIndex, cacheStateVersion };
+}
+
+bool StudioModel::hasRenderableMeshes() const
+{
+    return !mdl_mesh_groups.empty() || !frameCache.empty();
+}
 
 void StudioModel::CalcBoneAdj()
 {
@@ -602,7 +664,10 @@ void StudioModel::RefreshMeshList(int body)
 
 		for (int j = 0; j < m_pmodel->nummesh; j++)
 		{
-			mdl_mesh_groups[body][j].buffer = new VertexBuffer(g_app->modelShader, NULL, 0, GL_TRIANGLES);
+			if (!mdl_mesh_groups[body][j].buffer)
+			{
+				mdl_mesh_groups[body][j].buffer = std::shared_ptr<VertexBuffer>(new VertexBuffer(g_app->modelShader, NULL, 0, GL_TRIANGLES));
+			}
 		}
 	}
 
@@ -757,22 +822,22 @@ void StudioModel::RefreshMeshList(int body)
 			}
 		}
 
-		if ((int)mdl_mesh_groups[body][j].verts.size() < totalElements)
+		if ((int)mdl_mesh_groups[body][j].verts->size() < totalElements)
 		{
-			mdl_mesh_groups[body][j].verts.resize(totalElements);
-			mdl_mesh_groups[body][j].buffer->setData(&mdl_mesh_groups[body][j].verts[0], (int)(mdl_mesh_groups[body][j].verts.size()));
+			mdl_mesh_groups[body][j].verts->resize(totalElements);
+			mdl_mesh_groups[body][j].buffer->setData(&(*mdl_mesh_groups[body][j].verts)[0], (int)mdl_mesh_groups[body][j].verts->size());
 		}
-		for (int z = 0; z < (int)mdl_mesh_groups[body][j].verts.size(); z++)
+		for (int z = 0; z < (int)mdl_mesh_groups[body][j].verts->size(); z++)
 		{
-			mdl_mesh_groups[body][j].verts[z].u = texCoordData[z * 2 + 0];
-			mdl_mesh_groups[body][j].verts[z].v = texCoordData[z * 2 + 1];
-			/*mdl_mesh_groups[body][j].verts[z].r = colorData[z * 4 + 0];
-			mdl_mesh_groups[body][j].verts[z].g = colorData[z * 4 + 1];
-			mdl_mesh_groups[body][j].verts[z].b = colorData[z * 4 + 2];
-			mdl_mesh_groups[body][j].verts[z].a = 1.0;*/
-			mdl_mesh_groups[body][j].verts[z].pos.x = vertexData[z * 3 + 0];
-			mdl_mesh_groups[body][j].verts[z].pos.y = vertexData[z * 3 + 2];
-			mdl_mesh_groups[body][j].verts[z].pos.z = -vertexData[z * 3 + 1];
+			(*mdl_mesh_groups[body][j].verts)[z].u = texCoordData[z * 2 + 0];
+			(*mdl_mesh_groups[body][j].verts)[z].v = texCoordData[z * 2 + 1];
+			/*(*mdl_mesh_groups[body][j].verts)[z].r = colorData[z * 4 + 0];
+			(*mdl_mesh_groups[body][j].verts)[z].g = colorData[z * 4 + 1];
+			(*mdl_mesh_groups[body][j].verts)[z].b = colorData[z * 4 + 2];
+			(*mdl_mesh_groups[body][j].verts)[z].a = 1.0;*/
+			(*mdl_mesh_groups[body][j].verts)[z].pos.x = vertexData[z * 3 + 0];
+			(*mdl_mesh_groups[body][j].verts)[z].pos.y = vertexData[z * 3 + 2];
+			(*mdl_mesh_groups[body][j].verts)[z].pos.z = -vertexData[z * 3 + 1];
 
 			if (needForceUpdate)
 			{
@@ -895,100 +960,158 @@ studioseqhdr_t* StudioModel::LoadDemandSequences(const std::string& modelname, i
 
 void StudioModel::DrawMDL(int meshnum)
 {
-	if (frametime < 0.0f)
-		frametime = g_app->curTime;
+    if (frametime < 0.0f)
+        frametime = g_app->curTime;
 
-	if (needForceUpdate || (g_app->curTime - frametime > (1.0f / fps) && !ortho_overview && (g_render_flags & RENDER_MODELS_ANIMATED)))
-	{
-		if (needForceUpdate)
-		{
-			if (mdl_mesh_groups.size())
-			{
-				for (auto& body : mdl_mesh_groups)
-				{
-					if (body.size())
-					{
-						for (auto& submesh : body)
-						{
-							delete submesh.buffer;
-						}
-					}
-				}
-			}
-			mdl_mesh_groups = std::vector<std::vector<StudioMesh>>();
-		}
+    bool animationEnabled = (g_render_flags & RENDER_MODELS_ANIMATED) && !ortho_overview;
+    double currentTime = g_app->curTime;
 
-		if (mdl_mesh_groups.size())
-		{
-			for (auto& body : mdl_mesh_groups)
-			{
-				if (body.size())
-				{
-					for (auto& submesh : body)
-					{
-						if (submesh.buffer)
-						{
-							submesh.buffer->uploaded = false;
-						}
-					}
-				}
-			}
-		}
+    int frameIndex = static_cast<int>(std::floor(m_frame));
 
-		AdvanceFrame((1.0f / fps));
-		UpdateModelMeshList();
-		this->frametime = -1.0f;
-	}
+    double advanceDurationMs = 0.0;
+    bool frameAdvanced = false;
 
-	needForceUpdate = false;
+    if (animationEnabled)
+    {
+        double deltaSeconds = 0.0;
+        if (m_prevAnimTime > 0.0)
+            deltaSeconds = currentTime - m_prevAnimTime;
+        if (deltaSeconds < 0.0)
+            deltaSeconds = 0.0;
+        if (deltaSeconds > 0.1)
+            deltaSeconds = 0.1;
+        m_prevAnimTime = currentTime;
 
+        if (deltaSeconds > 0.0 && fps > FLT_EPSILON)
+        {
+            using clock = std::chrono::steady_clock;
+            auto advanceStart = clock::now();
+            AdvanceFrame(static_cast<float>(deltaSeconds));
+            auto advanceEnd = clock::now();
+            advanceDurationMs = std::chrono::duration<double, std::milli>(advanceEnd - advanceStart).count();
 
-	if (meshnum >= 0)
-	{
-		if (mdl_mesh_groups.size() && meshnum < (int)mdl_mesh_groups[0].size())
-		{
-			Texture* validTexture = mdl_mesh_groups[0][meshnum].texture;
+            frameIndex = static_cast<int>(std::floor(m_frame));
+            if (frameIndex != m_lastFrameIndex)
+            {
+                frameAdvanced = true;
+                m_lastFrameIndex = frameIndex;
+            }
+        }
+    }
+    else
+    {
+        m_prevAnimTime = currentTime;
+        frameIndex = static_cast<int>(std::floor(m_frame));
+    }
 
-			if (mdl_mesh_groups[0][meshnum].texture)
-			{
-				mdl_mesh_groups[0][meshnum].texture->bind(0);
-			}
-			else if (validTexture)
-			{
-				validTexture->bind(0);
-			}
-			else
-			{
-				whiteTex->bind(0);
-			}
-			mdl_mesh_groups[0][meshnum].buffer->drawFull();
-		}
-	}
-	else
-	{
-		for (size_t group = 0; group < mdl_mesh_groups.size(); group++)
-		{
-			for (size_t meshid = 0; meshid < mdl_mesh_groups[group].size(); meshid++)
-			{
-				Texture* validTexture = mdl_mesh_groups[group][meshid].texture;
+    std::shared_ptr<CachedFrame> cachedFrame;
+    bool cacheHit = false;
 
-				if (mdl_mesh_groups[group][meshid].texture)
-				{
-					mdl_mesh_groups[group][meshid].texture->bind(0);
-				}
-				else if (validTexture)
-				{
-					validTexture->bind(0);
-				}
-				else
-				{
-					whiteTex->bind(0);
-				}
-				mdl_mesh_groups[group][meshid].buffer->drawFull();
-			}
-		}
-	}
+    FrameKey key = makeFrameKey(frameIndex);
+
+    if (!needForceUpdate)
+    {
+        auto it = frameCache.find(key);
+        if (it != frameCache.end())
+        {
+            cachedFrame = it->second;
+            cacheHit = cachedFrame != nullptr;
+        }
+    }
+    else
+    {
+        invalidateFrameCache();
+    }
+
+    bool shouldRefresh = needForceUpdate || !cacheHit;
+
+    if (shouldRefresh)
+    {
+        bool forceUpdate = needForceUpdate;
+
+        if (needForceUpdate)
+        {
+            mdl_mesh_groups.clear();
+        }
+
+        if (!mdl_mesh_groups.empty())
+        {
+            for (auto& body : mdl_mesh_groups)
+            {
+                for (auto& submesh : body)
+                {
+                    if (submesh.buffer)
+                    {
+                        submesh.buffer->uploaded = false;
+                    }
+                }
+            }
+        }
+
+        UpdateModelMeshList();
+
+        cachedFrame = buildCachedFrame();
+        frameCache[key] = cachedFrame;
+        cacheHit = true;
+    }
+
+    needForceUpdate = false;
+
+    const auto& drawMeshGroups = (cacheHit && cachedFrame) ? cachedFrame->meshGroups : mdl_mesh_groups;
+
+    if (cachedFrame && cachedFrame->hasBounds)
+    {
+        mins = cachedFrame->mins;
+        maxs = cachedFrame->maxs;
+    }
+
+    if (meshnum >= 0)
+    {
+        if (!drawMeshGroups.empty() && meshnum < (int)drawMeshGroups[0].size())
+        {
+            Texture* validTexture = drawMeshGroups[0][meshnum].texture;
+
+            if (drawMeshGroups[0][meshnum].texture)
+            {
+                drawMeshGroups[0][meshnum].texture->bind(0);
+            }
+            else if (validTexture)
+            {
+                validTexture->bind(0);
+            }
+            else
+            {
+                whiteTex->bind(0);
+            }
+            drawMeshGroups[0][meshnum].buffer->drawFull();
+        }
+    }
+    else
+    {
+        for (size_t group = 0; group < drawMeshGroups.size(); group++)
+        {
+            for (size_t meshid = 0; meshid < drawMeshGroups[group].size(); meshid++)
+            {
+                Texture* validTexture = drawMeshGroups[group][meshid].texture;
+
+                if (drawMeshGroups[group][meshid].texture)
+                {
+                    drawMeshGroups[group][meshid].texture->bind(0);
+                }
+                else if (validTexture)
+                {
+                    validTexture->bind(0);
+                }
+                else
+                {
+                    whiteTex->bind(0);
+                }
+                drawMeshGroups[group][meshid].buffer->drawFull();
+            }
+        }
+    }
 }
+
 
 void StudioModel::Init(const std::string& modelname)
 {
@@ -1081,6 +1204,9 @@ int StudioModel::SetSequence(int iSequence)
 	if (iSequence != m_sequence)
 	{
 		needForceUpdate = true;
+		m_lastFrameIndex = -1;
+		m_prevAnimTime = 0.0;
+		invalidateFrameCache();
 	}
 	m_sequence = iSequence;
 	m_frame = 0;
@@ -1106,7 +1232,11 @@ int StudioModel::SetSkin(int iValue)
 	}
 
 	if (iValue != m_skinnum)
+	{
 		needForceUpdate = true;
+		m_lastFrameIndex = -1;
+		invalidateFrameCache();
+	}
 
 	m_skinnum = iValue;
 	return iValue;
@@ -1306,6 +1436,7 @@ int StudioModel::SetBodygroup(int iGroup, int iValue)
 	m_bodynum = (m_bodynum - (iCurrent * pbodypart->base) + (iValue * pbodypart->base));
 
 	needForceUpdate = true;
+	invalidateFrameCache();
 
 	return iValue;
 }

--- a/src/mdl/mdl_studio.h
+++ b/src/mdl/mdl_studio.h
@@ -10,7 +10,10 @@
 #include "Texture.h"
 #include "PointEntRenderer.h"
 
+#include <functional>
 #include <map>
+#include <memory>
+#include <unordered_map>
 /***
 *
 *	Copyright (c) 1996-2002, Valve LLC. All rights reserved.
@@ -336,19 +339,66 @@ typedef struct mstudioevent_s
 
 struct StudioMesh
 {
-	VertexBuffer* buffer;
+	std::shared_ptr<VertexBuffer> buffer;
 	Texture* texture;
-	std::vector<modelVert> verts;
+	std::shared_ptr<std::vector<modelVert>> verts;
+
 	StudioMesh()
+		: buffer(nullptr), texture(nullptr), verts(std::make_shared<std::vector<modelVert>>())
 	{
-		buffer = NULL;
-		texture = NULL;
-		verts = std::vector<modelVert>();
 	}
+
+	// Explicitly define copy and move operations
+	StudioMesh(const StudioMesh& other) = default;
+	StudioMesh(StudioMesh&& other) noexcept = default;
+	StudioMesh& operator=(const StudioMesh& other) = default;
+	StudioMesh& operator=(StudioMesh&& other) noexcept = default;
+	~StudioMesh() = default;
 };
 
 class StudioModel
 {
+	struct FrameKey
+	{
+		int sequence;
+		int body;
+		int skin;
+		int frame;
+		int stateVersion;
+
+		bool operator==(const FrameKey& other) const noexcept
+		{
+			return sequence == other.sequence && body == other.body && skin == other.skin && frame == other.frame && stateVersion == other.stateVersion;
+		}
+	};
+
+	struct FrameKeyHash
+	{
+		std::size_t operator()(const FrameKey& key) const noexcept
+		{
+			std::size_t h = std::hash<int>{}(key.sequence);
+			h ^= std::hash<int>{}(key.body) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(key.skin) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(key.frame) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(key.stateVersion) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			return h;
+		}
+	};
+
+	struct CachedFrame
+	{
+		std::vector<std::vector<StudioMesh>> meshGroups;
+		vec3 mins;
+		vec3 maxs;
+		bool hasBounds = false;
+	};
+
+
+private:
+	void invalidateFrameCache();
+	std::shared_ptr<CachedFrame> buildCachedFrame();
+	FrameKey makeFrameKey(int frameIndex) const;
+
 public:
 	// entity settings
 	float fps;
@@ -398,8 +448,14 @@ public:
 	vec4 m_adj;				// FIX: non persistant, make static
 	std::vector<Texture*> mdl_textures;
 	std::vector<std::vector<StudioMesh>> mdl_mesh_groups;
+	std::unordered_map<FrameKey, std::shared_ptr<CachedFrame>, FrameKeyHash> frameCache;
+	int cacheStateVersion = 0;
 
 	std::string filename;
+
+	bool hasRenderableMeshes() const;
+	double m_prevAnimTime;
+	int m_lastFrameIndex;
 
 	StudioModel(std::string modelname) : filename(std::move(modelname))
 	{
@@ -417,11 +473,15 @@ public:
 		g_lambert = 1.0f;
 		mdl_textures = std::vector<Texture*>();
 		mdl_mesh_groups = std::vector<std::vector<StudioMesh>>();
+		frameCache.clear();
+		cacheStateVersion = 0;
 		m_sequence = m_skinnum = 0;
 		m_frame = 0.0f;
 		m_mouth = 0;
 		m_pstudiohdr = NULL;
 		m_pmodel = NULL;
+        m_prevAnimTime = 0.0;
+        m_lastFrameIndex = -1;
 
 		for (int i = 0; i < 32; i++)
 		{
@@ -494,17 +554,8 @@ public:
 		{
 			delete[] m_panimhdr[i];
 		}
-		for (auto& body : mdl_mesh_groups)
-		{
-			for (auto& submesh : body)
-			{
-				if (submesh.buffer)
-				{
-					delete submesh.buffer;
-				}
-			}
-		}
-		mdl_mesh_groups.clear();
+	mdl_mesh_groups.clear();
+	frameCache.clear();
 	}
 
 	void DrawMDL(int mesh = -1);


### PR DESCRIPTION
Previously, every animation frame would rebuild and re-upload all visible model geometry to the GPU, causing significant FPS drops when viewing maps with many animated models loaded from FGDs. Now caches skinned frames by (sequence, body, skin, frame) and reuses GPU buffers. Frame cache invalidates on state changes. Converted StudioMesh to use shared_ptr and implemented move semantics for VertexBuffer to support the caching implementation

Uncached (I did not want to make the video too long, but we slowly drop to between 5-10 FPS):

https://github.com/user-attachments/assets/f7100d48-7e66-4af0-a3d1-9c4ae004e983

Cached:

https://github.com/user-attachments/assets/38f19b2a-26a9-4121-a523-32d064f9a0c2

For anyone wanting to test, you can find a release over on my [fork](https://github.com/MisterCalvin/newbspguy/releases/tag/NightBuild_2025.10.24_02-13) (the release says it is built from newbspguy_master HEAD, but that's incorrect - you can see the [artifacts](https://github.com/MisterCalvin/newbspguy/actions/runs/18767465655) were built from the HEAD commit on my fix branch)